### PR TITLE
Change the encryption/compression information in the FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,7 @@ FAQ
 
 **Q** Is s3git compatible to git at the binary level?  
 **A** No. git is optimized for text content with very nice and powerful diffing and using compressed storage whereas s3git is more focused on large repos with primarily non-text blobs backed up cloud storage like S3.  
-**Q** Do you support encryption?  
-**A** No. However it is trivial to encrypt data before streaming into `s3git add`, eg pipe it through `openssl enc` or similar.  
-**Q** Do you support zipping?  
-**A** No. Again it is trivial to zip it before streaming into `s3git add`, eg pipe it through `zip -r - .` or similar.  
+**Q** Do you support encryption and/or compression?  
+**A** Not yet, but we plan to add pluggable modules that can transform blobs before storing/fetching them. Transforming at the blob level prevents that unchanged blobs are also updated. Most transformations (compression and most encryption algorithms) use a transformation that also alter all bytes following the changed bytes.     
 **Q** Why don't you provide a FUSE interface?  
 **A** Supporting FUSE would mean introducing a lot of complexity related to POSIX which we would rather avoid.  


### PR DESCRIPTION
Using transformations (such as encryption/compression) will have an effect on the changed blob and all the blobs following them. Suppose you change the first byte in a 1GB file, then all 200 blobs will be different and need to be reuploaded. When the compression is done on the blob level, then only the changed part needs to be reuploaded.

This change would be a bit more difficult to implement, because of the following changes:
- Transformations should be done from within s3git, so you need a (pluggable) module to do this.
- Slightly more overhead, because each blob is compressed/encrypted on its own.
- A single encryption key should be used for the entire repository.

This encryption should only be used to encrypt the repository, because the underlying storage layer cannot be trusted. It cannot be used to encrypt individual files (with different keys), because each blob should have the same key. If you do need per-file encryption, then you need to encrypt the file using the traditional methods.

The data will be stored with the hash of the transformed data. Because during the encryption of a block a randomized initialization vector is used, the encrypted data cannot use deduplication anymore. If you do want to use deduplication, then you have two options:
- Use the hash of the untransformed data as the IV (potentially unsecure, because IVs should be random).
- Store the file in the underlying storage using the untransformed hash. The drawback of this is that you cannot scrub each block to check if it hasn't been altered (without knowing the key).
