### PR TITLE
add viper config and read from configuration files

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -120,8 +120,4 @@ func init() {
 	RootCmd.AddCommand(cloneCmd)
 
 	// Add local message flags
-	// TODO: 'Duplicate' flags for remote add command -- refactor into single definition
-	cloneCmd.Flags().StringVarP(&accessKey, "access", "a", "", "Access key for S3 remote")
-	cloneCmd.Flags().StringVarP(&secretKey, "secret", "s", "", "Secret key for S3 remote")
-	cloneCmd.Flags().StringVarP(&endpoint, "endpoint", "e", "", "Endpoint for S3 remote")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,9 +24,6 @@ import (
 )
 
 var resource string
-var accessKey string
-var secretKey string
-var endpoint string
 
 var leafSize uint32
 var maxRepoSize uint64

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -108,8 +108,4 @@ func init() {
 
 	// Add local message flags
 	remoteAddCmd.Flags().StringVarP(&resource, "resource", "r", "", "URL for remote S3")
-	remoteAddCmd.Flags().StringVarP(&accessKey, "access", "a", "", "Access key for remote S3")
-	remoteAddCmd.Flags().StringVarP(&secretKey, "secret", "s", "", "Secret key for remote S3")
-	remoteAddCmd.Flags().StringVarP(&endpoint, "endpoint", "e", "", "Endpoint for remote S3")
 }
-

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,12 +21,17 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func er(msg interface{}) {
 	fmt.Println("Error:", msg)
 	os.Exit(-1)
 }
+
+var endpoint string
+var accessKey string
+var secretKey string
 
 // This represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -49,6 +54,14 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	cmd := RootCmd
+	cmd.PersistentFlags().StringVarP(&accessKey, "access", "a", "", "Access key for S3 remote")
+	viper.BindPFlag("access", cmd.PersistentFlags().Lookup("access"))
+	cmd.PersistentFlags().StringVarP(&secretKey, "secret", "s", "", "Secret key for S3 remote")
+	viper.BindPFlag("secret", cmd.PersistentFlags().Lookup("secret"))
+	cmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "e", "", "Endpoint for S3 remote")
+	viper.BindPFlag("endpoint", cloneCmd.PersistentFlags().Lookup("endpoint"))
 }
 
 // initConfig reads in config file

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"github.com/s3git/s3git/cmd"
+	"github.com/spf13/viper"
 	"os"
 )
 
@@ -28,6 +29,38 @@ func main() {
 	if len(os.Args) > 1 && os.Args[1] == "version" && version != "" {
 		fmt.Println(version)
 		os.Exit(0)
+	}
+
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("s3git")
+	viper.SetConfigName("config") // name of config file (without extension)
+	viper.AddConfigPath("/etc/s3git/")
+	viper.AddConfigPath("$HOME/.s3git")
+
+	// AWS_PROFILE or S3GIT_PROFILE can set the profile
+	viper.BindEnv("profile", "AWS_PROFILE");
+
+	for _, ext := range []string{"json", "yaml", "yml"} {
+		viper.SetConfigType(ext)
+		err := viper.ReadInConfig() // Find and read config files
+		if err != nil { // Handle errors reading the config file
+			if _, ok := err.(viper.ConfigParseError); ok {
+				panic(fmt.Errorf("Fatal error reading " + ext + " config file: %s \n", err))
+			}
+		}
+	}
+
+	for _, extrafile := range []string{"$HOME/.aws/config", "$HOME/.aws/credentials"} {
+
+		viper.SetConfigType("yaml") // TODO: this should be INI
+		viper.SetConfigFile(extrafile) // name of config file (without extension)
+		err := viper.ReadInConfig() // Find and read the config file
+
+		if err != nil { // Handle errors reading the config file
+			if _, ok := err.(viper.ConfigParseError); ok {
+				panic(fmt.Errorf("Fatal error reading config file: %s \n", err))
+			}
+		}
 	}
 
 	//TODO: Investigate: do we set the max procs somewhere?


### PR DESCRIPTION
This is my first attempt. Please note I'm just starting to use Go.

* use https://github.com/spf13/viper in `root.go`
* move access, secret, and endpoint arguments to global and shadow them with `viper.BindPFlags` (which resolves some TODOs already in place)
* accept any variable in the environment, e.g. `S3GIT_ACCESS` is then `viper.GetString("access")`
* add a global profile argument, also can be set with `AWS_PROFILE` from the environment
* try to load from paths `/etc/s3git`, `~/.s3git` with filenames `config.json`, `config.yaml`, and `config.yml`
* try to load `~/.aws/config` and `~/.aws/credentials` as YAML (to be INI when Viper supports it)

Not working: the Viper binding to the Cobra flags. Even though `viper.GetString("access")` has `foobar` showing that the configuration is loaded from `echo '{ "access": "foobar" }' > ~/.s3git/config.json`, the `accessKey` variable doesn't get `foobar`. This may be something about the order in which things are loaded, or I may have missed something.